### PR TITLE
fix: ensure container always returns DONE error JSON on failure

### DIFF
--- a/streamline_puller/main.py
+++ b/streamline_puller/main.py
@@ -128,5 +128,5 @@ if __name__ == "__main__":
     try:
         config = load_config(args.config)
         run(config)
-    except ConfigError as e:
+    except Exception as e:
         fail(e)


### PR DESCRIPTION
## Summary
- Catch all exceptions at the top level in `main.py` (not just `ConfigError`) so API errors, data processing failures, and unexpected exceptions always produce the `DONE {"status": "error", "error": "..."}` response instead of crashing the container silently
- Improve error messages in V1/V2 clients to include URLs, HTTP status codes, and response bodies for easier debugging
- Replace bare `except:` clauses with specific exception types to preserve error context
- Remove raw `print()` error logging in V2 `get_token` that polluted stdout and could interfere with the DONE protocol
- Add missing `raise_for_status()` calls in V2 `get_occupancies` and `get_inspections`

## Test plan
- [ ] Deploy container with invalid credentials and verify `DONE {"status": "error", ...}` is printed to stdout
- [ ] Deploy container with valid credentials against a working Streamline instance and verify `DONE {"status": "ok", ...}` still works
- [ ] Verify error messages contain actionable context (URL, status code, response body)